### PR TITLE
Fix a broken link

### DIFF
--- a/_posts/2019-10-04-release-0.22.3-and-fuzzit-dev.md
+++ b/_posts/2019-10-04-release-0.22.3-and-fuzzit-dev.md
@@ -34,7 +34,7 @@ available as a service as well, very similar to hosting and CI. We're also glad
 to announce that fuzzit.dev allows us to their platform as an open source
 organization.  Thank you,
 
-[![](https://fuzzit.dev/wp-content/uploads/2019/09/logo-alt.png)](fuzzit.dev)
+[![](https://fuzzit.dev/wp-content/uploads/2019/09/logo-alt.png)][fuzzit]
 
 They have also been welcoming and helped out where possible with the setup. The
 `png` decoder in particular has been happily running and did not turn up


### PR DESCRIPTION
The link in the post didn't contain a host component, so it was broken.