### PR TITLE
Post about handle change

### DIFF
--- a/_posts/2025-names-are-hard.md
+++ b/_posts/2025-names-are-hard.md
@@ -1,0 +1,7 @@
+## Changing my Github user handle
+
+As of soon, expectedly within RustWeek 2025, my Github handle will change to
+@197g [&nbsp;][1] corresponding to real life changes. This post, as a signed
+commit, signifies the provenance of this change.
+
+[1]: # "formerly @HeroicKatora"


### PR DESCRIPTION
As of soon, expectedly within RustWeek 2025, my Github handle will change to
@197g  corresponding to real life changes. This post, as a signed
commit, signifies the provenance of this change.